### PR TITLE
fix: use top-level typescript-language-server package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
             with pkgs;
             [
               nodejs_24
-              nodejs_24.pkgs.typescript-language-server
+              typescript-language-server
               ripgrep
               git
               git-lfs


### PR DESCRIPTION
## Problem

`nodejs_24.pkgs` attribute no longer exists in recent `nixos-unstable`, causing:

```
error: attribute 'pkgs' missing
at flake.nix:27:15:
    26|               nodejs_24
    27|               nodejs_24.pkgs.typescript-language-server
```

## Fix

`typescript-language-server` is now available as a top-level nixpkgs package. Replace the broken reference with the top-level attribute.

```nix
# Before
nodejs_24.pkgs.typescript-language-server

# After
typescript-language-server
```